### PR TITLE
Upgrade AGP to 7.4.2, migrate jcenter to mavenCentral, fix imports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ buildscript {
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -18,7 +18,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/constants.gradle
+++ b/constants.gradle
@@ -20,7 +20,7 @@ project.ext {
     // - Backup/restore can access to the external directory
     // - Disabled auto start of the background service (e.g. remote control service)
     targetSdkVersion = 29 // 35 max
-    compileSdkVersion = 33
+    compileSdkVersion = 34
     buildToolsVersion = '30.0.3'
     //gradleVersion = '6.9.1' // https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
     //androidGradleVersion = '4.0.0+' // last version compatible with IntellJ 2020.3

--- a/sharedutils/src/main/java/com/liskovsoft/sharedutils/okhttp/PublicDnsResolver.java
+++ b/sharedutils/src/main/java/com/liskovsoft/sharedutils/okhttp/PublicDnsResolver.java
@@ -3,7 +3,13 @@ package com.liskovsoft.sharedutils.okhttp;
 import androidx.annotation.NonNull;
 
 import okhttp3.Dns;
-import org.xbill.DNS.*;
+import org.xbill.DNS.ARecord;
+import org.xbill.DNS.AAAARecord;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.Resolver;
+import org.xbill.DNS.SimpleResolver;
+import org.xbill.DNS.Type;
 
 import java.io.IOException;
 import java.net.InetAddress;


### PR DESCRIPTION
- Upgrade AGP from 3.1.0 to 7.4.2
- Replace jcenter() with mavenCentral()
- Bump compileSdkVersion from 33 to 34
- Replace wildcard import with explicit imports in PublicDnsResolver