### PR TITLE
CronetManager: Improved QUIC support

### DIFF
--- a/sharedutils/src/main/java/com/liskovsoft/sharedutils/cronet/CronetManager.kt
+++ b/sharedutils/src/main/java/com/liskovsoft/sharedutils/cronet/CronetManager.kt
@@ -2,6 +2,7 @@ package com.liskovsoft.sharedutils.cronet
 
 import android.content.Context
 import com.liskovsoft.sharedutils.mylogger.Log
+import java.io.File
 import org.chromium.net.CronetEngine
 import org.chromium.net.ExperimentalCronetEngine
 import org.chromium.net.impl.NativeCronetProvider
@@ -23,12 +24,17 @@ object CronetManager {
             //    .build()
 
             try {
+                val cacheDir = File(context.cacheDir, "StCronet")
+                cacheDir.mkdirs()
+
                 val builder = NativeCronetProvider(context).createBuilder()
 
                 builder
                     .enableQuic(true)
                     .enableHttp2(true)
                     .enableBrotli(true)
+                    .setStoragePath(cacheDir.absolutePath)
+                    .enableHttpCache(CronetEngine.Builder.HTTP_CACHE_DISK_NO_HTTP, 2 * 1024 * 1024)
                     //.addQuicHint("youtube.com", 80, 80)
 
                 // Do these tweaks have negative side effects?


### PR DESCRIPTION
Prevents unnecessary TCP connections before QUIC is established.

This is the proper version of https://github.com/yuliskov/SmartTube/pull/5633
I do not know whether this can fix automatically translated subtitles, but it at least eliminates unnecessary TCP connections when streaming video.

CronetEngine.Builder.HTTP_CACHE_DISK_NO_HTTP do not cache HTTP response data. Maximum cache size is 2 MB.

Reference GoogleChromeLabs cronet-sample https://github.com/GoogleChromeLabs/cronet-sample/blob/50221f75d16bc948235f5a8f66c853af8770732c/android/app/src/main/java/com/google/samples/cronet_sample/CronetApplication.java#L67 Enable on-disk cache, this enables automatic QUIC usage for subsequent requests to the same domain across application restarts. HTTP2 and QUIC support is enabled by default. When both are enabled (and no hints are provided), Cronet tries to use both protocols and it's nondeterministic which one will be used for the first few requests. As soon as Cronet is aware that a server supports QUIC, it will always attempt to use it first.