### PR TITLE
perf(rx): use bounded ThreadPoolExecutor with CPU core scaling and idle timeout

### DIFF
--- a/sharedutils/src/main/java/com/liskovsoft/sharedutils/rx/RxHelper.java
+++ b/sharedutils/src/main/java/com/liskovsoft/sharedutils/rx/RxHelper.java
@@ -23,6 +23,8 @@ import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -34,7 +36,19 @@ public class RxHelper {
 
     private static Scheduler getCachedScheduler() {
         if (sCachedScheduler == null) {
-            sCachedScheduler = Schedulers.from(Executors.newCachedThreadPool());
+            int cores = Runtime.getRuntime().availableProcessors();
+            int corePoolSize = Math.max(2, Math.min(4, cores));
+            int maxPoolSize = Math.max(4, Math.min(8, cores * 2));
+            ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                    corePoolSize,
+                    maxPoolSize,
+                    60L,
+                    TimeUnit.SECONDS,
+                    new LinkedBlockingQueue<>(),
+                    new ThreadPoolExecutor.CallerRunsPolicy()
+            );
+            executor.allowCoreThreadTimeOut(true);
+            sCachedScheduler = Schedulers.from(executor);
         }
 
         return sCachedScheduler;


### PR DESCRIPTION
### Summary of Changes

In \RxHelper.java\, replace unbounded \Executors.newCachedThreadPool()\ with a CPU-aware bounded \ThreadPoolExecutor\.

### Problem Statement & Context
- \Executors.newCachedThreadPool()\ allows an unbounded number of threads (\Integer.MAX_VALUE\).
- Under bursty I/O or rapid remote D-pad navigation and thumbnail loading on low-spec Android TV devices (especially 1GB RAM devices like Fire TV Stick Lite, Gen 2, and Gen 3), thread explosion leads to native memory exhaustion, OutOfMemoryErrors (\pthread_create failed: Out of memory\), and UI thread jank.

### Solution
- Configures \ThreadPoolExecutor\ with:
  - **Core pool size:** Scaled dynamically to available CPU cores: \Math.max(2, Math.min(4, cores))\.
  - **Maximum pool size:** Capped dynamically: \Math.max(4, Math.min(8, cores * 2))\.
  - **Keep-alive time:** 60 seconds with \llowCoreThreadTimeOut(true)\ so idle threads are aggressively reclaimed and do not consume resident memory when idle.
  - **Work queue:** \LinkedBlockingQueue\ for pending tasks.
  - **Rejection policy:** \ThreadPoolExecutor.CallerRunsPolicy\ to gracefully throttle and apply backpressure if capacity is ever saturated.

### Related
- SmartTube PR: https://github.com/yuliskov/SmartTube/pull/6160